### PR TITLE
Adapt to newer version of Node, update Eastwood and ZooKeeper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,13 @@ repl:
 
 lint: cljlint jslint
 
+
 cljlint:
-	lein with-profile $(profile),$(profile)-test eastwood "{:exclude-linters [:deprecations]}"
+ifeq ($(profile), cdh4)
+		lein with-profile $(profile),$(profile)-test eastwood "{:exclude-linters [:deprecations :reflection]}"
+else
+		lein with-profile $(profile),$(profile)-test eastwood "{:exclude-linters [:deprecations]}"
+endif
 
 resources/public/js/core.js: resources/jsx/core.jsx
 	node_modules/.bin/babel resources/jsx/core.jsx --out-file $@

--- a/package.json
+++ b/package.json
@@ -10,5 +10,8 @@
     "gulp-rename": "^1.2.2",
     "natives": "^1.1.6",
     "standard": "^5.3.1"
+  },
+  "overrides": {
+    "graceful-fs": "^4.2.10"
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(def project-version "0.3.7")
+(def project-version "0.3.8")
 (def current :1.0)
 (defn bin [profile]
   (str "hbase-region-inspector-" project-version (when (not= profile current)
@@ -29,7 +29,7 @@
             [codox "0.8.12"]           ; lein doc
             [com.jakemccrary/lein-test-refresh "0.10.0"]
             [lein-pprint "1.1.2"]      ; lein pprint
-            [jonase/eastwood "0.2.1"]] ; lein eastwood
+            [jonase/eastwood "1.3.0"]] ; lein eastwood
   :ring {:handler hbase-region-inspector.core/app
          :nrepl {:start? true :port 9999}}
   :jvm-opts ["-Xmx2g" "-Dclojure.compiler.direct-linking=true"]
@@ -66,5 +66,6 @@
                  :target-path  "target/1.0"
                  :source-paths ["src/hbase-1.0"]
                  :dependencies [[org.apache.hbase/hbase-client "1.0.0"]
-                                [org.apache.hbase/hbase-common "1.0.0"]]}
+                                [org.apache.hbase/hbase-common "1.0.0"]
+                                [org.apache.zookeeper/zookeeper "3.5.7"]]}
    :uberjar {:aot :all}})

--- a/src/main/hbase_region_inspector/core.clj
+++ b/src/main/hbase_region_inspector/core.clj
@@ -441,7 +441,7 @@
          (throw (Exception. "Read-only mode. Not allowed.")))
        (hbase/with-admin
          [admin @config]
-         (.move ^org.apache.hadoop.hbase.client.Admin admin (.getBytes ^String region) (.getBytes ^String dest))
+         (.move ^org.apache.hadoop.hbase.client.HBaseAdmin admin (.getBytes ^String region) (.getBytes ^String dest))
          (loop [tries 20
                 message (format "Moving %s from %s to %s" region src dest)]
            (util/info message)

--- a/src/main/hbase_region_inspector/core.clj
+++ b/src/main/hbase_region_inspector/core.clj
@@ -441,7 +441,7 @@
          (throw (Exception. "Read-only mode. Not allowed.")))
        (hbase/with-admin
          [admin @config]
-         (.move admin (.getBytes ^String region) (.getBytes ^String dest))
+         (.move ^org.apache.hadoop.hbase.client.Admin admin (.getBytes ^String region) (.getBytes ^String dest))
          (loop [tries 20
                 message (format "Moving %s from %s to %s" region src dest)]
            (util/info message)

--- a/src/main/hbase_region_inspector/hbase/base.clj
+++ b/src/main/hbase_region_inspector/hbase/base.clj
@@ -1,29 +1,33 @@
-(ns hbase-region-inspector.hbase.base)
+(ns hbase-region-inspector.hbase.base
+  (:import [org.apache.hadoop.hbase
+            RegionLoad]
+           [org.apache.hadoop.hbase
+            HRegionInfo]))
 
 (defn info->map
   "Builds map from HRegionInfo"
   [info]
-  {:encoded-name (.getEncodedName info)
+  {:encoded-name (.getEncodedName ^HRegionInfo info)
    ; :table
-   :start-key    (.getStartKey info)
-   :end-key      (.getEndKey info)
-   :meta?        (.isMetaRegion info)})
+   :start-key    (.getStartKey ^HRegionInfo info)
+   :end-key      (.getEndKey ^HRegionInfo info)
+   :meta?        (.isMetaRegion ^HRegionInfo info)})
 
 (defn load->map
   "Builds map from RegionLoad"
   [load]
-  {:compacted-kvs              (.getCurrentCompactedKVs load)
-   :memstore-size-mb           (.getMemStoreSizeMB load)
-   :read-requests              (.getReadRequestsCount load)
-   :requests                   (.getRequestsCount load)
-   :root-index-size-kb         (.getRootIndexSizeKB load)
-   :store-file-index-size-mb   (.getStorefileIndexSizeMB load)
-   :store-files                (.getStorefiles load)
-   :store-file-size-mb         (.getStorefileSizeMB load)
-   :stores                     (.getStores load)
+  {:compacted-kvs              (.getCurrentCompactedKVs ^RegionLoad load)
+   :memstore-size-mb           (.getMemStoreSizeMB ^RegionLoad load)
+   :read-requests              (.getReadRequestsCount ^RegionLoad load)
+   :requests                   (.getRequestsCount ^RegionLoad load)
+   :root-index-size-kb         (.getRootIndexSizeKB ^RegionLoad load)
+   :store-file-index-size-mb   (.getStorefileIndexSizeMB ^RegionLoad load)
+   :store-files                (.getStorefiles ^RegionLoad load)
+   :store-file-size-mb         (.getStorefileSizeMB ^RegionLoad load)
+   :stores                     (.getStores ^RegionLoad load)
    ; :store-uncompressed-size-mb
-   :total-compacting-kvs       (.getTotalCompactingKVs load)
-   :bloom-size-kb              (.getTotalStaticBloomSizeKB load)
-   :total-index-size-kb        (.getTotalStaticIndexSizeKB load)
-   :write-requests             (.getWriteRequestsCount load)})
+   :total-compacting-kvs       (.getTotalCompactingKVs ^RegionLoad load)
+   :bloom-size-kb              (.getTotalStaticBloomSizeKB ^RegionLoad load)
+   :total-index-size-kb        (.getTotalStaticIndexSizeKB ^RegionLoad load)
+   :write-requests             (.getWriteRequestsCount ^RegionLoad load)})
 

--- a/src/main/hbase_region_inspector/hbase/base.clj
+++ b/src/main/hbase_region_inspector/hbase/base.clj
@@ -1,7 +1,5 @@
 (ns hbase-region-inspector.hbase.base
   (:import [org.apache.hadoop.hbase
-            RegionLoad]
-           [org.apache.hadoop.hbase
             HRegionInfo]))
 
 (defn info->map
@@ -12,22 +10,4 @@
    :start-key    (.getStartKey ^HRegionInfo info)
    :end-key      (.getEndKey ^HRegionInfo info)
    :meta?        (.isMetaRegion ^HRegionInfo info)})
-
-(defn load->map
-  "Builds map from RegionLoad"
-  [load]
-  {:compacted-kvs              (.getCurrentCompactedKVs ^RegionLoad load)
-   :memstore-size-mb           (.getMemStoreSizeMB ^RegionLoad load)
-   :read-requests              (.getReadRequestsCount ^RegionLoad load)
-   :requests                   (.getRequestsCount ^RegionLoad load)
-   :root-index-size-kb         (.getRootIndexSizeKB ^RegionLoad load)
-   :store-file-index-size-mb   (.getStorefileIndexSizeMB ^RegionLoad load)
-   :store-files                (.getStorefiles ^RegionLoad load)
-   :store-file-size-mb         (.getStorefileSizeMB ^RegionLoad load)
-   :stores                     (.getStores ^RegionLoad load)
-   ; :store-uncompressed-size-mb
-   :total-compacting-kvs       (.getTotalCompactingKVs ^RegionLoad load)
-   :bloom-size-kb              (.getTotalStaticBloomSizeKB ^RegionLoad load)
-   :total-index-size-kb        (.getTotalStaticIndexSizeKB ^RegionLoad load)
-   :write-requests             (.getWriteRequestsCount ^RegionLoad load)})
 

--- a/src/main/hbase_region_inspector/util.clj
+++ b/src/main/hbase_region_inspector/util.clj
@@ -35,11 +35,11 @@
   []
   (let [addrs (->> (java.net.NetworkInterface/getNetworkInterfaces)
                    enumeration-seq
-                   (filter #(.isUp %))
-                   (remove #(.isLoopback %))
-                   (mapcat #(enumeration-seq (.getInetAddresses %)))
+                   (filter #(.isUp ^java.net.NetworkInterface %))
+                   (remove #(.isLoopback ^java.net.NetworkInterface %))
+                   (mapcat #(enumeration-seq (.getInetAddresses ^java.net.NetworkInterface %)))
                    (filter #(instance? java.net.Inet4Address %))
-                   (map #(.getHostAddress %)))]
+                   (map #(.getHostAddress ^java.net.InetAddress %)))]
     (if (empty? addrs) ["127.0.0.1"] addrs)))
 
 (defn keyword->str


### PR DESCRIPTION
My employer, HubSpot, has gotten great use out of the HBase Region Inspector for many years. Thank you! We are currently working on securing our ZooKeeper connections, and for the first time, the existing builds of the region inspector were not sufficient.

For your consideration, this PR
- Upgrades the ZooKeeper package used from 3.4.x to 3.5.x, introducing support for secure connections. 
- Makes a frontend change to work with NodeJS 19.x
- Uses the newest version of the Clojure linter, because the existing version simply crashed for me. Consequently, I've also fixed all the newly introduced linter warnings.
- Bumps the version number to 0.3.8

If you are interested, I can also follow up this PR with another that adds support for HBase 2.x, and versions of Java beyond 8.